### PR TITLE
update charts and doc to version 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Solutions currently included in this project:
 * [The ShardingSphere Helm Charts](https://github.com/apache/shardingsphere-on-cloud/tree/main/charts/shardingsphere-proxy)
 * [The ShardingSphere Operator](https://github.com/apache/shardingsphere-on-cloud/tree/main/shardingsphere-operator)
 
+## Current Status
+
+Currently, either [The ShardingSphere Helm Charts](https://github.com/apache/shardingsphere-on-cloud/tree/main/charts/shardingsphere-proxy) and [The ShardingSphere Operator](https://github.com/apache/shardingsphere-on-cloud/tree/main/shardingsphere-operator) would create the latest version as 5.2.0 of ShardingSphere Proxy. Just following the Quick Start and give it a try!
+
+* [The ShardingSphere Helm Charts QuickStart](#quick-start)
+* [The ShardingSphere Operator QuickStart](#quick-start-1)
 
 ## ShardingSphere Helm Charts
 
@@ -30,7 +36,7 @@ The ShardingSphere Helm Charts uses [Helm](https://helm.sh/) to provide guidance
 
 ### Quick Start
 
-Please follows [instructions](./doc/shardingsphere-helm-charts.md) to deploy a ShardingSphere cluster with version 5.1.2
+Please follows [instructions](./doc/shardingsphere-helm-charts.md) to deploy a ShardingSphere cluster with version 5.2.0.
 
 ## ShardingSphere Operator
 
@@ -52,7 +58,7 @@ Minimum Viable Product
 
 ### Quick Start 
 
-Please follows [instructions](./doc/shardingsphere-operator.md) to deploy a ShardingSphere cluster with version 5.1.2
+Please follows [instructions](./doc/shardingsphere-operator.md) to deploy a ShardingSphere cluster with version 5.2.0.
 
 ### Features
 

--- a/charts/shardingsphere-cluster/values.yaml
+++ b/charts/shardingsphere-cluster/values.yaml
@@ -20,7 +20,7 @@
 ## @param proxyVersion ShardingSphere-Proxy cluster version
 ##
 replicaCount: "3"
-proxyVersion: "5.1.2"
+proxyVersion: "5.2.0"
 ## @param automaticScaling.enable ShardingSphere-Proxy Whether the ShardingSphere-Proxy cluster has auto-scaling enabled
 ## @param automaticScaling.scaleUpWindows ShardingSphere-Proxy automatically scales the stable window
 ## @param automaticScaling.scaleDownWindows ShardingSphere-Proxy automatically shrinks the stabilized window

--- a/charts/shardingsphere-proxy/Chart.yaml
+++ b/charts/shardingsphere-proxy/Chart.yaml
@@ -16,7 +16,7 @@
 #
 
 apiVersion: v2
-appVersion: 5.1.3
+appVersion: 5.2.0
 name: apache-shardingsphere-proxy
 version: 1.1.1
 maintainers:

--- a/charts/shardingsphere-proxy/values.yaml
+++ b/charts/shardingsphere-proxy/values.yaml
@@ -67,7 +67,7 @@ compute:
     pullPolicy: IfNotPresent
     ## Overrides the image tag whose default is the chart appVersion.
     ##
-    tag: "5.1.2"
+    tag: "5.2.0"
   ## @param compute.imagePullSecrets Specify docker-registry secret names as an array
   ## e.g：
   ## imagePullSecrets:

--- a/doc/shardingsphere-helm-charts.md
+++ b/doc/shardingsphere-helm-charts.md
@@ -70,7 +70,7 @@ helm uninstall shardingsphere-proxy
 | ----------------------------------- | ------------------------------------------------------------ |-------------------------------|
 | `compute.image.repository`          | Image name of ShardingSphere-Proxy.                          | `apache/shardingsphere-proxy` |
 | `compute.image.pullPolicy`          | The policy for pulling ShardingSphere-Proxy image            | `IfNotPresent`                |
-| `compute.image.tag`                 | ShardingSphere-Proxy image tag                               | `5.1.2`                       |
+| `compute.image.tag`                 | ShardingSphere-Proxy image tag                               | `5.2.0`                       |
 | `compute.imagePullSecrets`          | Specify docker-registry secret names as an array             | `[]`                          |
 | `compute.resources.limits`          | The resources limits for the ShardingSphere-Proxy containers | `{}`                          |
 | `compute.resources.requests.memory` | The requested memory for the ShardingSphere-Proxy containers | `2Gi`                         |
@@ -156,7 +156,7 @@ compute:
     pullPolicy: IfNotPresent
     ## Overrides the image tag whose default is the chart appVersion.
     ##
-    tag: "5.1.2"
+    tag: "5.2.0"
   ## @param compute.imagePullSecrets Specify docker-registry secret names as an array
   ## e.g：
   ## imagePullSecrets:

--- a/doc/shardingsphere-operator.md
+++ b/doc/shardingsphere-operator.md
@@ -52,7 +52,7 @@ helm install  shardingsphere-cluster shardingspherecloud/shardingsphere-cluster 
 | Name                                | Description                                                                                                                                                                                        | Value       |
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | `replicaCount`                      | ShardingSphere-Proxy cluster starts the number of replicas, Note: After you enable automaticScaling, this parameter will no longer take effect                                                     | `3`         |
-| `proxyVersion`                      | ShardingSphere-Proxy cluster version                                                                                                                                                               | `5.1.2`     |
+| `proxyVersion`                      | ShardingSphere-Proxy cluster version                                                                                                                                                               | `5.2.0`     |
 | `automaticScaling.enable`           | ShardingSphere-Proxy Whether the ShardingSphere-Proxy cluster has auto-scaling enabled                                                                                                             | `false`     |
 | `automaticScaling.scaleUpWindows`   | ShardingSphere-Proxy automatically scales the stable window                                                                                                                                        | `30`        |
 | `automaticScaling.scaleDownWindows` | ShardingSphere-Proxy automatically shrinks the stabilized window                                                                                                                                   | `30`        |
@@ -155,7 +155,7 @@ shardingsphere-cluster/values.yaml
 ## @param proxyVersion ShardingSphere-Proxy cluster version
 ##
 replicaCount: "3"
-proxyVersion: "5.1.2"
+proxyVersion: "5.2.0"
 ## @param automaticScaling.enable ShardingSphere-Proxy Whether the ShardingSphere-Proxy cluster has auto-scaling enabled
 ## @param automaticScaling.scaleUpWindows ShardingSphere-Proxy automatically scales the stable window
 ## @param automaticScaling.scaleDownWindows ShardingSphere-Proxy automatically shrinks the stabilized window


### PR DESCRIPTION
Update docs and charts to version 5.2.0, including:
- ShardingSphere Proxy Helm Charts and docs
-  ShardingSphere Cluster(for Operator) default Helm Charts and docs
- README