### PR TITLE
chore(ci): add basic integration test for ShardingSphere Proxy Helm Charts

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: integration test
 
 on: push 
@@ -28,7 +45,8 @@ jobs:
           helm install shardingsphere-proxy shardingsphere-proxy -n ${TEST_NAMESPACE}
           kubectl wait --timeout=60s --for=condition=Ready --all pod -n ${TEST_NAMESPACE}
           kubectl get pod -n ${TEST_NAMESPACE} --show-labels
-          kubectl port-forward svc/shardingsphere-proxy 3307:3307 -n ${TEST_NAMESPACE} &
+          kubectl get svc -n ${TEST_NAMESPACE} --show-labels
+          kubectl port-forward svc/shardingsphere-proxy-apache-shardingsphere-proxy 3307:3307 -n ${TEST_NAMESPACE} &
           sleep 3
       - name: "prepare mysql" 
         uses: shogo82148/actions-setup-mysql@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,31 @@
+name: integration test
+
+on: push 
+
+jobs:
+  run:
+    name: Integration Test for ShardingSphere Proxy Helm Charts
+    runs-on: ubuntu-latest 
+    steps:
+      - name: "checkout codes" 
+        uses: actions/checkout@v3
+      - name: "setup kind"
+        uses: helm/kind-action@v1.2.0
+      - name: "setup helm"
+        uses: azure/setup-helm@v2.1
+      - name: "setup kubectl" 
+        uses: azure/setup-kubectl@v2.0
+      - name: "Test Helm Charts for ShardingSphere Proxy"
+        run: |
+          set -x 
+          export TEST_NAMESPACE="shardingsphere-system"
+          kubectl create namespace ${TEST_NAMESPACE}
+          cd shardingsphere-proxy/charts/governance
+          helm dependency build 
+          cd ../..
+          helm dependency build 
+          cd ..
+          helm install shardingsphere-proxy shardingsphere-proxy -n ${TEST_NAMESPACE}
+          kubectl wait --timeout=60s --for=condition=Ready --all pod -n ${TEST_NAMESPACE}
+          kubectl get pod -n ${TEST_NAMESPACE} --show-labels
+          sleep 3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -52,5 +52,5 @@ jobs:
         uses: shogo82148/actions-setup-mysql@v1
         with:
          mysql-version: '5.7'
-      - name: "run basic select test" 
+      - name: "run basic cmd test" 
         run: mysql -h127.0.0.1 -P3307 -uroot -proot -e 'SHOW DATABASES'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ jobs:
           set -x 
           export TEST_NAMESPACE="shardingsphere-system"
           kubectl create namespace ${TEST_NAMESPACE}
-          cd shardingsphere-proxy/charts/governance
+          cd charts/shardingsphere-proxy/charts/governance
           helm dependency build 
           cd ../..
           helm dependency build 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,4 +28,11 @@ jobs:
           helm install shardingsphere-proxy shardingsphere-proxy -n ${TEST_NAMESPACE}
           kubectl wait --timeout=60s --for=condition=Ready --all pod -n ${TEST_NAMESPACE}
           kubectl get pod -n ${TEST_NAMESPACE} --show-labels
+          kubectl port-forward svc/shardingsphere-proxy 3307:3307 -n ${TEST_NAMESPACE} &
           sleep 3
+      - name: "prepare mysql" 
+        uses: shogo82148/actions-setup-mysql@v1
+        with:
+         mysql-version: '5.7'
+      - name: "run basic select test" 
+        run: mysql -h127.0.0.1 -P3307 -uroot -proot -e 'SELECT UNIX_TIMESTAMP()'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,4 +53,4 @@ jobs:
         with:
          mysql-version: '5.7'
       - name: "run basic select test" 
-        run: mysql -h127.0.0.1 -P3307 -uroot -proot -e 'SELECT UNIX_TIMESTAMP()'
+        run: mysql -h127.0.0.1 -P3307 -uroot -proot -e 'SHOW DATABASES'


### PR DESCRIPTION
Currently the procedure is:
- Setup a Kind cluster
- Prepare Helm tools
- Installing ShardingSphere Proxy and Zookeeper with commands provided by the document
- Setup a local MySQL instance
- Connect with ShardingSphere Service and run some basic statements