### PR TITLE
Feat(operator): add isLeader metric for operator 

### DIFF
--- a/shardingsphere-operator/build/Dockerfile
+++ b/shardingsphere-operator/build/Dockerfile
@@ -29,12 +29,13 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
+COPY cmd/shardingsphere-operator/manager cmd/shardingsphere-operator/manager/
+COPY cmd/shardingsphere-operator/main.go cmd/shardingsphere-operator/main.go
 COPY api api/
 COPY pkg pkg/
 RUN mkdir -p certs && cd certs && openssl req -new -SHA256 -newkey rsa:2048 -nodes -keyout tls.key -out tls.csr -subj "/C=CN/ST=beijing/L=beijing/O=/OU=/" && openssl x509 -req -sha256 -days 365 -in tls.csr -signkey tls.key -out tls.crt
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build  -ldflags "-w -s" -gcflags "-N -l" -a -o operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build  -ldflags "-w -s" -gcflags "-N -l" -a -o operator cmd/shardingsphere-operator/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/shardingsphere-operator/cmd/shardingsphere-operator/main.go
+++ b/shardingsphere-operator/cmd/shardingsphere-operator/main.go
@@ -35,6 +35,7 @@ func main() {
 	if err := manager.New(opt).
 		SetHealthzCheck("healthz", healthz.Ping).
 		SetReadyzCheck("readyz", healthz.Ping).
+		SetMetrics().
 		Start(ctrl.SetupSignalHandler()); err != nil {
 		os.Exit(1)
 	}

--- a/shardingsphere-operator/cmd/shardingsphere-operator/manager/manager.go
+++ b/shardingsphere-operator/cmd/shardingsphere-operator/manager/manager.go
@@ -20,6 +20,7 @@ package manager
 import (
 	"context"
 	"flag"
+	"github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/pkg/metrics"
 	"os"
 
 	"github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/api/v1alpha1"
@@ -114,6 +115,15 @@ func (mgr *Manager) SetReadyzCheck(path string, check healthz.Checker) *Manager 
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
+	return mgr
+}
+
+func (mgr *Manager) SetMetrics() *Manager {
+	if err := mgr.Add(metrics.NewLeaderElectionMetric(mgr.Elected())); err != nil {
+		setupLog.Error(err, "unable to add LeaderElection Metric")
+		os.Exit(1)
+	}
+
 	return mgr
 }
 

--- a/shardingsphere-operator/pkg/metrics/metrics.go
+++ b/shardingsphere-operator/pkg/metrics/metrics.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package metrics
 
 import (

--- a/shardingsphere-operator/pkg/metrics/metrics.go
+++ b/shardingsphere-operator/pkg/metrics/metrics.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"context"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"strconv"
+)
+
+const (
+	metricsNamespace = "shardingsphere_proxy_operator"
+	leaderLabel      = "is_leader"
+)
+
+var (
+	isLeader = false
+)
+
+type LeaderElectionMetric struct {
+	elected <-chan struct{}
+	status  *prometheus.GaugeVec
+}
+
+var _ manager.LeaderElectionRunnable = &LeaderElectionMetric{}
+
+func (l *LeaderElectionMetric) Start(ctx context.Context) error {
+	// Set default label
+	l.status.WithLabelValues(strconv.FormatBool(isLeader)).Set(1)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-l.elected:
+				// The first, delete old label
+				l.status.Delete(prometheus.Labels{leaderLabel: strconv.FormatBool(isLeader)})
+				isLeader = true
+				// The second, recreate new label
+				l.status.WithLabelValues(strconv.FormatBool(isLeader)).Set(1)
+				isLeader = false
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// NeedLeaderElection implements controller-runtime's manager.LeaderElectionRunnable.
+func (l *LeaderElectionMetric) NeedLeaderElection() bool {
+	return false
+}
+
+func NewLeaderElectionMetric(elected <-chan struct{}) manager.Runnable {
+	isLeaderGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsNamespace,
+		Subsystem: "runtime",
+		Name:      "is_leader",
+		Help:      "This operator pod whether is the leader",
+	}, []string{leaderLabel})
+	metrics.Registry.MustRegister(isLeaderGauge)
+
+	return &LeaderElectionMetric{
+		elected: elected,
+		status:  isLeaderGauge,
+	}
+}


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

In order to monitor the operator, we need to know on which pod the leader is running, this PR provides `shardingsphere_proxy_operator_runtime_is_leader` metric.
### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?