### PR TITLE
feat: add kubebuild tag for scale subresource

### DIFF
--- a/shardingsphere-operator/api/v1alpha1/compute_node_types.go
+++ b/shardingsphere-operator/api/v1alpha1/compute_node_types.go
@@ -35,6 +35,7 @@ type ComputeNodeList struct {
 // +kubebuilder:printcolumn:JSONPath=".status.phase",name=Phase,type=string
 // +kubebuilder:printcolumn:JSONPath=".status.loadBalancer.clusterIP",name="ClusterIP",type=string
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.spec.selectors
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // ComputeNode is the Schema for the ShardingSphere Proxy API
@@ -311,6 +312,8 @@ type ComputeNodeSpec struct {
 
 // ComputeNodeStatus defines the observed state of ShardingSphere Proxy
 type ComputeNodeStatus struct {
+	Replicas int32 `json:"replicas"`
+
 	// The generation observed by the deployment controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`

--- a/shardingsphere-operator/pkg/controllers/compute_node_controller.go
+++ b/shardingsphere-operator/pkg/controllers/compute_node_controller.go
@@ -234,7 +234,7 @@ func (r *ComputeNodeReconciler) reconcileConfigMap(ctx context.Context, cn *v1al
 
 func (r *ComputeNodeReconciler) reconcileStatus(ctx context.Context, cn *v1alpha1.ComputeNode) error {
 	podList := &v1.PodList{}
-	if err := r.List(ctx, podList, client.InNamespace(cn.Namespace), client.MatchingLabels(cn.Labels)); err != nil {
+	if err := r.List(ctx, podList, client.InNamespace(cn.Namespace), client.MatchingLabels(cn.Spec.Selector.MatchLabels)); err != nil {
 		return err
 	}
 
@@ -255,6 +255,8 @@ func (r *ComputeNodeReconciler) reconcileStatus(ctx context.Context, cn *v1alpha
 	}
 
 	rt.Status = reconcileComputeNodeStatus(*podList, *service, *rt)
+
+	rt.Status.Replicas = int32(len(podList.Items))
 
 	// TODO: Compare Status with or without modification
 	if err := r.Status().Update(ctx, rt); err != nil {


### PR DESCRIPTION
This pr supports scale ComputeNode with `kubectl scale ComputeNode xxx --replicas=xxx`

related to #166 