### PR TITLE
chore: update operator charts default image from ghcr to dockerhub

### DIFF
--- a/charts/apache-shardingsphere-operator-charts/README.md
+++ b/charts/apache-shardingsphere-operator-charts/README.md
@@ -32,9 +32,9 @@ helm install [RELEASE_NAME] shardingsphere/apache-shardingsphere-operator-charts
 | Name                              | Description                                 | Value                                                                   |
 |-----------------------------------| ------------------------------------------- |-------------------------------------------------------------------------|
 | `operator.replicaCount`           | operator replica count                      | `2`                                                                     |
-| `operator.image.repository`       | operator image name                         | `ghcr.io/apache/shardingsphere-on-cloud/apache-shardingsphere-operator` |
+| `operator.image.repository`       | operator image name                         | `apache/shardingsphere-operator` |
 | `operator.image.pullPolicy`       | image pull policy                           | `IfNotPresent`                                                          |
-| `operator.image.tag`              | image tag                                   | `0.1.2`                                                                 |
+| `operator.image.tag`              | image tag                                   | `0.2.0`                                                                 |
 | `operator.imagePullSecrets`       | image pull secret of private repository     | `[]`                                                                    |
 | `operator.resources`              | operator Resources required by the operator | `{}`                                                                    |
 | `operator.health.healthProbePort` | operator health check port                  | `8081`                                                                  |

--- a/charts/apache-shardingsphere-operator-charts/values.yaml
+++ b/charts/apache-shardingsphere-operator-charts/values.yaml
@@ -28,7 +28,7 @@ operator:
   image:
     ## @param image.repository operator image name
     ##
-    repository: "ghcr.io/apache/shardingsphere-on-cloud/apache-shardingsphere-operator"
+    repository: "apache/shardingsphere-operator"
     ## @param image.pullPolicy image pull policy
     ##
     pullPolicy: IfNotPresent

--- a/docs/content/operation-guide/operator/_index.cn.md
+++ b/docs/content/operation-guide/operator/_index.cn.md
@@ -47,9 +47,9 @@ helm install [RELEASE_NAME] shardingsphere/apache-shardingsphere-operator-charts
 | Name                              | Description                                                                                                | Value                                                                   |
 |-----------------------------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
 | `operator.replicaCount`           | operator replica count                                                                                     | `2`                                                                     |
-| `operator.image.repository`       | operator image name                                                                                        | `ghcr.io/apache/shardingsphere-on-cloud/apache-shardingsphere-operator` |
+| `operator.image.repository`       | operator image name                                                                                        | `apache/shardingsphere-operator` |
 | `operator.image.pullPolicy`       | image pull policy                                                                                          | `IfNotPresent`                                                          |
-| `operator.image.tag`              | image tag                                                                                                  | `0.1.2`                                                                 |
+| `operator.image.tag`              | image tag                                                                                                  | `0.2.0`                                                                 |
 | `operator.imagePullSecrets`       | image pull secret of private repository                                                                    | `[]`                                                                    |
 | `operator.resources`              | operator Resources required by the operator                                                                | `{}`                                                                    |
 | `operator.health.healthProbePort` | operator health check port                                                                                 | `8081`                                                                  |
@@ -158,13 +158,13 @@ operator:
   image:
     ## @param image.repository operator image name
     ##
-    repository: "ghcr.io/apache/shardingsphere-on-cloud/apache-shardingsphere-operator"
+    repository: "apache/shardingsphere-operator"
     ## @param image.pullPolicy image pull policy
     ##
     pullPolicy: IfNotPresent
     ## @param image.tag image tag
     ##
-    tag: "0.1.2"
+    tag: "0.2.0"
   ## @param imagePullSecrets image pull secret of private repository
   ## e.g:
   ## imagePullSecrets:

--- a/docs/content/operation-guide/operator/_index.en.md
+++ b/docs/content/operation-guide/operator/_index.en.md
@@ -40,9 +40,9 @@ helm install shardingsphere-cluster apache-shardingsphere-operator-charts -n sha
 | Name                              | Description                                                                                               | Value                     |
 |-----------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------|
 | `operator.replicaCount`           | operator replica count                                                                                    | `2`                       |
-| `operator.image.repository`       | operator image name                                                                                        | `ghcr.io/apache/shardingsphere-on-cloud/apache-shardingsphere-operator` |
+| `operator.image.repository`       | operator image name                                                                                        | `apache/shardingsphere-operator` |
 | `operator.image.pullPolicy`       | image pull policy                                                                                         | `IfNotPresent`            |
-| `operator.image.tag`              | image tag                                                                                                 | `0.1.2`                   |
+| `operator.image.tag`              | image tag                                                                                                 | `0.2.0`                   |
 | `operator.imagePullSecrets`       | image pull secret of private repository                                                                   | `[]`                      |
 | `operator.resources`              | operator Resources required by the operator                                                               | `{}`                      |
 | `operator.health.healthProbePort` | operator health check port                                                                                | `8081`                    |
@@ -149,13 +149,13 @@ operator:
   image:
     ## @param image.repository operator image name
     ##
-    repository: "ghcr.io/apache/shardingsphere-on-cloud/apache-shardingsphere-operator"
+    repository: "apache/shardingsphere-operator"
     ## @param image.pullPolicy image pull policy
     ##
     pullPolicy: IfNotPresent
     ## @param image.tag image tag
     ##
-    tag: "0.1.2"
+    tag: "0.2.0"
   ## @param imagePullSecrets image pull secret of private repository
   ## e.g:
   ## imagePullSecrets:

--- a/docs/shardingsphere-operator.md
+++ b/docs/shardingsphere-operator.md
@@ -141,13 +141,13 @@ replicaCount: 2
 image:
   ## @param image.repository operator image name
   ##
-  repository: "ghcr.io/apache/shardingsphere-on-cloud/apache-shardingsphere-operator"
+  repository: "apache/shardingsphere-operator"
   ## @param image.pullPolicy image pull policy
   ##
   pullPolicy: IfNotPresent
   ## @param image.tag image tag
   ##
-  tag: "0.1.0"
+  tag: "0.2.0"
 ## @param imagePullSecrets image pull secret of private repository
 ## e.g:
 ## imagePullSecrets:


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:


### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

* Change helm charts of shardingsphere operator default image from ghcr hosted to Dockerhub hosted `apache/shardingsphere-operator`

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [x] Have you modified the corresponding document?