### PR TITLE
refactor(storage-node): refactor delete storage node logic

### DIFF
--- a/shardingsphere-operator/api/v1alpha1/storage_node_types.go
+++ b/shardingsphere-operator/api/v1alpha1/storage_node_types.go
@@ -140,7 +140,7 @@ type StorageNodeStatus struct {
 
 const (
 	StorageNodeInstanceStatusAvailable = "available"
-	StorageNodeInstanceStatusBackingup = "backingup"
+	StorageNodeInstanceStatusBackingUp = "backing-up"
 	StorageNodeInstanceStatusCreating  = "creating"
 	StorageNodeInstanceStatusDeleting  = "deleting"
 	StorageNodeInstanceStatusFailed    = "failed"
@@ -150,6 +150,8 @@ const (
 	StorageNodeInstanceStatusStarting  = "starting"
 	StorageNodeInstanceStatusStopped   = "stopped"
 	StorageNodeInstanceStatusStopping  = "stopping"
+
+	StorageNodeInstanceStatusReady = "Ready"
 )
 
 // AddCondition adds the given condition to the StorageNodeConditions.

--- a/shardingsphere-operator/cmd/shardingsphere-operator/manager/option.go
+++ b/shardingsphere-operator/cmd/shardingsphere-operator/manager/option.go
@@ -35,12 +35,10 @@ import (
 	dbmeshv1alpha1 "github.com/database-mesh/golang-sdk/kubernetes/api/v1alpha1"
 	"go.uber.org/zap/zapcore"
 	batchV1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -146,19 +144,11 @@ var featureGatesHandlers = map[string]FeatureGateHandler{
 		return nil
 	},
 	"StorageNode": func(mgr manager.Manager) error {
-		eventBroadcaster := record.NewBroadcaster()
-		recorder := eventBroadcaster.NewRecorder(
-			mgr.GetScheme(),
-			corev1.EventSource{
-				Component: controllers.StorageNodeControllerName,
-			},
-		)
-
 		reconciler := &controllers.StorageNodeReconciler{
 			Client:   mgr.GetClient(),
 			Scheme:   mgr.GetScheme(),
 			Log:      mgr.GetLogger(),
-			Recorder: recorder,
+			Recorder: mgr.GetEventRecorderFor(controllers.StorageNodeControllerName),
 		}
 
 		// init aws client if aws credentials are provided

--- a/shardingsphere-operator/pkg/controllers/storage_ndoe_controller_test.go
+++ b/shardingsphere-operator/pkg/controllers/storage_ndoe_controller_test.go
@@ -19,9 +19,12 @@ package controllers
 
 import (
 	"context"
+	"time"
+
 	"github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/api/v1alpha1"
 	"github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/pkg/reconcile/storagenode/aws"
 	mock_aws "github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/pkg/reconcile/storagenode/aws/mocks"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"bou.ke/monkey"
 	dbmesh_aws "github.com/database-mesh/golang-sdk/aws"
@@ -30,7 +33,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
@@ -41,49 +43,108 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var ctx = context.Background()
+const (
+	defaultTestNamespace          = "test-namespace"
+	defaultTestDBClass            = "test-database-class"
+	defaultTestStorageNode        = "test-storage-node"
+	defaultTestInstanceIdentifier = "test-database-instance"
+)
+
+var (
+	ctx        = context.Background()
+	fakeClient client.Client
+	reconciler *StorageNodeReconciler
+	mockCtrl   *gomock.Controller
+	mockAws    *mock_aws.MockIRdsClient
+)
+
+func fakeStorageNodeReconciler() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	scheme := runtime.NewScheme()
+	Expect(dbmeshv1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+	fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	sess := dbmesh_aws.NewSessions().SetCredential("AwsRegion", "AwsAccessKeyID", "AwsSecretAccessKey").Build()
+	reconciler = &StorageNodeReconciler{
+		Client:   fakeClient,
+		Log:      logf.Log,
+		Recorder: record.NewFakeRecorder(100),
+		AwsRDS:   dbmesh_rds.NewService(sess["AwsRegion"]),
+	}
+}
+
+var _ = BeforeEach(func() {
+	fakeStorageNodeReconciler()
+})
 
 var _ = Describe("StorageNode Controller Mock Test", func() {
-	var fakeClient client.Client
-	var reconciler *StorageNodeReconciler
 	BeforeEach(func() {
-		logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+		// mock aws rds client
+		mockCtrl = gomock.NewController(GinkgoT())
+		mockAws = mock_aws.NewMockIRdsClient(mockCtrl)
 
-		scheme := runtime.NewScheme()
-		Expect(dbmeshv1alpha1.AddToScheme(scheme)).To(Succeed())
-		Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
-		fakeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+		monkey.Patch(aws.NewRdsClient, func(rds dbmesh_rds.RDS) aws.IRdsClient {
+			return mockAws
+		})
 
-		eventBroadcaster := record.NewBroadcaster()
-		recorder := eventBroadcaster.NewRecorder(
-			scheme,
-			corev1.EventSource{
-				Component: "test-storage-node-controller",
+		// create default resource
+		dbClass := &dbmeshv1alpha1.DatabaseClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultTestDBClass,
 			},
-		)
-
-		sess := dbmesh_aws.NewSessions().SetCredential("AwsRegion", "AwsAccessKeyID", "AwsSecretAccessKey").Build()
-		reconciler = &StorageNodeReconciler{
-			Client:   fakeClient,
-			Log:      logf.Log,
-			Recorder: recorder,
-			AwsRDS:   dbmesh_rds.NewService(sess["AwsRegion"]),
+			Spec: dbmeshv1alpha1.DatabaseClassSpec{
+				Provisioner: dbmeshv1alpha1.ProvisionerAWSRDSInstance,
+			},
 		}
+
+		storageNode := &v1alpha1.StorageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultTestStorageNode,
+				Namespace: defaultTestNamespace,
+				Annotations: map[string]string{
+					dbmeshv1alpha1.AnnotationsInstanceIdentifier: defaultTestInstanceIdentifier,
+				},
+			},
+			Spec: v1alpha1.StorageNodeSpec{
+				DatabaseClassName: defaultTestDBClass,
+			},
+		}
+		Expect(fakeClient.Create(ctx, dbClass)).Should(Succeed())
+		Expect(fakeClient.Create(ctx, storageNode)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		// delete default resource
+		Expect(fakeClient.Delete(ctx, &v1alpha1.StorageNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      defaultTestStorageNode,
+				Namespace: defaultTestNamespace,
+			},
+		})).Should(Succeed())
+		Expect(fakeClient.Delete(ctx, &dbmeshv1alpha1.DatabaseClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: defaultTestDBClass,
+			},
+		})).Should(Succeed())
+
+		mockCtrl.Finish()
+		monkey.UnpatchAll()
 	})
 
 	Context("create storage node", func() {
 		It("should create storage node successfully", func() {
 			storageNode := &v1alpha1.StorageNode{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-storage-node",
-					Namespace: "test-namespace",
+					Name:      "test-storage-node-1",
+					Namespace: defaultTestNamespace,
 				},
 				Spec: v1alpha1.StorageNodeSpec{
-					DatabaseClassName: "test-database-class",
+					DatabaseClassName: defaultTestDBClass,
 				},
 				Status: v1alpha1.StorageNodeStatus{},
 			}
-
 			Expect(fakeClient.Create(ctx, storageNode)).Should(Succeed())
 			sn := &v1alpha1.StorageNode{}
 			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: "test-storage-node", Namespace: "test-namespace"}, sn)).Should(Succeed())
@@ -95,8 +156,8 @@ var _ = Describe("StorageNode Controller Mock Test", func() {
 		It("should create storage node successfully", func() {
 			storageNode := &v1alpha1.StorageNode{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-storage-node",
-					Namespace: "test-namespace",
+					Name:      "test-storage-node-2",
+					Namespace: defaultTestNamespace,
 				},
 				Spec: v1alpha1.StorageNodeSpec{
 					DatabaseClassName: "no-database",
@@ -106,8 +167,8 @@ var _ = Describe("StorageNode Controller Mock Test", func() {
 			Expect(fakeClient.Create(ctx, storageNode)).Should(Succeed())
 			req := ctrl.Request{
 				NamespacedName: client.ObjectKey{
-					Name:      "test-storage-node",
-					Namespace: "test-namespace",
+					Name:      "test-storage-node-2",
+					Namespace: defaultTestNamespace,
 				},
 			}
 			_, err := reconciler.Reconcile(ctx, req)
@@ -116,60 +177,17 @@ var _ = Describe("StorageNode Controller Mock Test", func() {
 		})
 	})
 
-	Context("reconcile storageNode with exist databaseClass", func() {
-		var mockCtrl *gomock.Controller
-		var mockAws *mock_aws.MockIRdsClient
-		BeforeEach(func() {
-			mockCtrl = gomock.NewController(GinkgoT())
-			mockAws = mock_aws.NewMockIRdsClient(mockCtrl)
-
-			monkey.Patch(aws.NewRdsClient, func(rds dbmesh_rds.RDS) aws.IRdsClient {
-				return mockAws
-			})
-
-			// create databaseClass
-			dbClass := &dbmeshv1alpha1.DatabaseClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-database-class",
-				},
-				Spec: dbmeshv1alpha1.DatabaseClassSpec{
-					Provisioner: dbmeshv1alpha1.ProvisionerAWSRDSInstance,
-				},
-			}
-			Expect(fakeClient.Create(ctx, dbClass)).Should(Succeed())
-
-			// create storageNode
-			storageNode := &v1alpha1.StorageNode{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-storage-node",
-					Namespace: "test-namespace",
-					Annotations: map[string]string{
-						dbmeshv1alpha1.AnnotationsInstanceIdentifier: "test-instance",
-					},
-				},
-				Spec: v1alpha1.StorageNodeSpec{
-					DatabaseClassName: "test-database-class",
-				},
-			}
-
-			Expect(fakeClient.Create(ctx, storageNode)).Should(Succeed())
-		})
-
-		AfterEach(func() {
-			mockCtrl.Finish()
-			monkey.UnpatchAll()
-		})
-
+	Context("reconcile storageNode", func() {
 		It("should reconcile successfully with Creating Instance", func() {
 			req := ctrl.Request{
 				NamespacedName: client.ObjectKey{
-					Name:      "test-storage-node",
-					Namespace: "test-namespace",
+					Name:      defaultTestStorageNode,
+					Namespace: defaultTestNamespace,
 				},
 			}
 
 			rdsInstance := &dbmesh_rds.DescInstance{
-				DBInstanceStatus: "creating",
+				DBInstanceStatus: v1alpha1.StorageNodeInstanceStatusCreating,
 				Endpoint: dbmesh_rds.Endpoint{
 					Address: "127.0.0.1",
 					Port:    3306,
@@ -186,19 +204,19 @@ var _ = Describe("StorageNode Controller Mock Test", func() {
 			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: "test-storage-node", Namespace: "test-namespace"}, newSN)).Should(Succeed())
 			Expect(newSN.Status.Phase).To(Equal(v1alpha1.StorageNodePhaseNotReady))
 			Expect(newSN.Status.Instances).To(HaveLen(1))
-			Expect(newSN.Status.Instances[0].Status).To(Equal("creating"))
+			Expect(newSN.Status.Instances[0].Status).To(Equal(v1alpha1.StorageNodeInstanceStatusCreating))
 		})
 
 		It("should reconcile successfully with Available Instance", func() {
 			req := ctrl.Request{
 				NamespacedName: client.ObjectKey{
-					Name:      "test-storage-node",
-					Namespace: "test-namespace",
+					Name:      defaultTestStorageNode,
+					Namespace: defaultTestNamespace,
 				},
 			}
 
 			rdsInstance := &dbmesh_rds.DescInstance{
-				DBInstanceStatus: "available",
+				DBInstanceStatus: v1alpha1.StorageNodeInstanceStatusAvailable,
 				Endpoint: dbmesh_rds.Endpoint{
 					Address: "127.0.0.1",
 					Port:    3306,
@@ -211,44 +229,155 @@ var _ = Describe("StorageNode Controller Mock Test", func() {
 			Expect(err).To(BeNil())
 
 			newSN := &v1alpha1.StorageNode{}
-			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: "test-storage-node", Namespace: "test-namespace"}, newSN)).Should(Succeed())
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: defaultTestStorageNode, Namespace: defaultTestNamespace}, newSN)).Should(Succeed())
 
 			Expect(newSN.Status.Phase).To(Equal(v1alpha1.StorageNodePhaseReady))
 			Expect(newSN.Status.Instances).To(HaveLen(1))
-			Expect(newSN.Status.Instances[0].Status).To(Equal("Ready"))
+			Expect(newSN.Status.Instances[0].Status).To(Equal(v1alpha1.StorageNodeInstanceStatusReady))
 		})
+	})
 
-		It("should reconcile successfully when storage node be deleted", func() {
-			req := ctrl.Request{
-				NamespacedName: client.ObjectKey{
-					Name:      "test-storage-node",
-					Namespace: "test-namespace",
-				},
-			}
-
-			rdsInstance := &dbmesh_rds.DescInstance{
-				DBInstanceStatus: "available",
+	Context("reconcile storage node in Ready status when it's been deleted", func() {
+		var (
+			rdsInstanceAvailable = dbmesh_rds.DescInstance{
+				DBInstanceIdentifier: defaultTestInstanceIdentifier,
+				DBInstanceStatus:     v1alpha1.StorageNodeInstanceStatusAvailable,
 				Endpoint: dbmesh_rds.Endpoint{
 					Address: "127.0.0.1",
 					Port:    3306,
 				},
 			}
-
-			// mock aws rds client, get instance
-			mockAws.EXPECT().GetInstance(gomock.Any(), gomock.Any()).Return(rdsInstance, nil).AnyTimes()
+			instanceInDeleting = dbmesh_rds.DescInstance{
+				DBInstanceIdentifier: defaultTestInstanceIdentifier,
+				DBInstanceStatus:     v1alpha1.StorageNodeInstanceStatusDeleting,
+				Endpoint: dbmesh_rds.Endpoint{
+					Address: "127.0.0.1",
+					Port:    3306,
+				},
+			}
+		)
+		It("should be successful when instance is in available status", func() {
+			deletingStorageNode := "test-deleting-storage-node"
+			req := ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      deletingStorageNode,
+					Namespace: defaultTestNamespace,
+				},
+			}
+			readyStorageNode := &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deletingStorageNode,
+					Namespace: defaultTestNamespace,
+					Annotations: map[string]string{
+						dbmeshv1alpha1.AnnotationsInstanceIdentifier: defaultTestInstanceIdentifier,
+					},
+				},
+				Spec: v1alpha1.StorageNodeSpec{DatabaseClassName: defaultTestDBClass},
+			}
+			Expect(fakeClient.Create(ctx, readyStorageNode)).Should(Succeed())
+			// mock aws rds client, get instance and return available status
+			mockAws.EXPECT().GetInstance(gomock.Any(), gomock.Any()).Return(&rdsInstanceAvailable, nil)
 			// reconcile storage node, add instance and set status to ready
 			_, err := reconciler.Reconcile(ctx, req)
 			Expect(err).To(BeNil())
 
 			// delete storage node
-			sn := &v1alpha1.StorageNode{}
-			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: "test-storage-node", Namespace: "test-namespace"}, sn)).Should(Succeed())
-			Expect(fakeClient.Delete(ctx, sn)).Should(Succeed())
-
+			Expect(fakeClient.Delete(ctx, &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deletingStorageNode,
+					Namespace: defaultTestNamespace,
+				},
+			})).Should(Succeed())
 			// mock aws rds client, delete instance
+			mockAws.EXPECT().GetInstance(gomock.Any(), gomock.Any()).Return(&rdsInstanceAvailable, nil)
 			mockAws.EXPECT().DeleteInstance(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			mockAws.EXPECT().GetInstance(gomock.Any(), gomock.Any()).Return(&instanceInDeleting, nil)
 			_, err = reconciler.Reconcile(ctx, req)
 			Expect(err).To(BeNil())
+
+			// storage node status should be deleting
+			deletingSN := &v1alpha1.StorageNode{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: deletingStorageNode, Namespace: defaultTestNamespace}, deletingSN)).Should(Succeed())
+			Expect(deletingSN.Status.Phase).To(Equal(v1alpha1.StorageNodePhaseDeleting))
+		})
+
+		It("should be successful when instance is in deleting status", func() {
+			deletedStorageNodeName := "test-deleted-storage-node"
+			req := ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      deletedStorageNodeName,
+					Namespace: defaultTestNamespace,
+				},
+			}
+			deleteTime := metav1.NewTime(time.Now())
+			storageNode := &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deletedStorageNodeName,
+					Namespace: defaultTestNamespace,
+					Finalizers: []string{
+						FinalizerName,
+					},
+					DeletionTimestamp: &deleteTime,
+				},
+				Spec: v1alpha1.StorageNodeSpec{
+					DatabaseClassName: defaultTestDBClass,
+				},
+				Status: v1alpha1.StorageNodeStatus{
+					Phase: v1alpha1.StorageNodePhaseDeleting,
+					Instances: []v1alpha1.InstanceStatus{
+						{
+							Status: v1alpha1.StorageNodeInstanceStatusDeleting,
+							Endpoint: v1alpha1.Endpoint{
+								Address: "127.0.0.1",
+								Port:    3306,
+							},
+						},
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, storageNode)).Should(Succeed())
+			// mock aws rds client, get nil instance
+			mockAws.EXPECT().GetInstance(gomock.Any(), gomock.Any()).Return(nil, nil)
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).To(BeNil())
+
+			deletedCompleteSN := &v1alpha1.StorageNode{}
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: deletedStorageNodeName, Namespace: defaultTestNamespace}, deletedCompleteSN)).Should(Succeed())
+			Expect(deletedCompleteSN.Status.Phase).To(Equal(v1alpha1.StorageNodePhaseDeleteComplete))
+		})
+
+		It("should be successful when storage node is delete complete status", func() {
+			deletedCompletedStorageNodeName := "test-delete-completed-storage-node"
+			req := ctrl.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      deletedCompletedStorageNodeName,
+					Namespace: defaultTestNamespace,
+				},
+			}
+			deleteTime := metav1.NewTime(time.Now())
+			storageNode := &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      deletedCompletedStorageNodeName,
+					Namespace: defaultTestNamespace,
+					Finalizers: []string{
+						FinalizerName,
+					},
+					DeletionTimestamp: &deleteTime,
+				},
+				Spec: v1alpha1.StorageNodeSpec{
+					DatabaseClassName: defaultTestDBClass,
+				},
+				Status: v1alpha1.StorageNodeStatus{
+					Phase: v1alpha1.StorageNodePhaseDeleteComplete,
+				},
+			}
+			Expect(fakeClient.Create(ctx, storageNode)).Should(Succeed())
+
+			_, err := reconciler.Reconcile(ctx, req)
+			Expect(err).To(BeNil())
+			finalSN := &v1alpha1.StorageNode{}
+			err = fakeClient.Get(ctx, client.ObjectKey{Name: deletedCompletedStorageNodeName, Namespace: defaultTestNamespace}, finalSN)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	})
 })

--- a/shardingsphere-operator/pkg/reconcile/storagenode/aws/rdsinstance.go
+++ b/shardingsphere-operator/pkg/reconcile/storagenode/aws/rdsinstance.go
@@ -183,6 +183,7 @@ func (c *RdsClient) DeleteInstance(ctx context.Context, node *v1alpha1.StorageNo
 	if err != nil {
 		return err
 	}
+
 	if ins == nil || ins.DBInstanceStatus == v1alpha1.StorageNodeInstanceStatusDeleting {
 		return nil
 	}
@@ -196,10 +197,9 @@ func (c *RdsClient) DeleteInstance(ctx context.Context, node *v1alpha1.StorageNo
 	case dbmeshv1alpha1.DatabaseReclaimRetain:
 		isDeleteBackup, isSkipFinalSnapshot = false, true
 	}
+
 	instance.SetDeleteAutomateBackups(isDeleteBackup)
 	instance.SetSkipFinalSnapshot(isSkipFinalSnapshot)
 
-	// instance.SetDeleteAutomateBackups(true)
-	// instance.SetSkipFinalSnapshot(true)
 	return instance.Delete(ctx)
 }


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [x] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fix the bug about update status failed coz resource be modified, now we move all update status logic on the top of reconcile func.
- use `slices.Contains` and `slices.Filter` to replace our own `containsString` and 'removeString`.
- fix reconciler event recorder error.
- refactor test cases of testing `delete storage node`.
- fix bug of storage node will be reconciled if it is deleting (with finalizer), if storage node be deleting, we don't need to reconcile any resource anymore.
### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?