### PR TITLE
feat(storage-node): unregister storage unit when storage node be deleted

### DIFF
--- a/shardingsphere-operator/pkg/shardingsphere/shardingsphere.go
+++ b/shardingsphere-operator/pkg/shardingsphere/shardingsphere.go
@@ -39,9 +39,7 @@ const (
 	DistSQLDropTable = `DROP TABLE %s;`
 )
 
-var (
-	ruleTypeMap = map[string]string{}
-)
+var ruleTypeMap = map[string]string{}
 
 type Rule struct {
 	Type string
@@ -142,21 +140,10 @@ func (s *server) UnRegisterStorageUnit(dsName string) error {
 		return fmt.Errorf("get rules used error: %w", err)
 	}
 
-	// TODO DISCUSS: should we drop all tables used by storage unit?
-	// clean all rules and tables used by storage unit
-	tables := map[string]struct{}{}
+	// clean all rules used by storage unit
 	for _, rule := range rules {
 		if err := s.dropRule(rule.Type, rule.Name); err != nil {
 			return fmt.Errorf("drop rule error: %w", err)
-		}
-		if _, ok := tables[rule.Name]; !ok {
-			tables[rule.Name] = struct{}{}
-		}
-	}
-
-	for table := range tables {
-		if err := s.dropTable(table); err != nil {
-			return fmt.Errorf("drop table error: %w", err)
 		}
 	}
 
@@ -177,15 +164,6 @@ func (s *server) dropRule(ruleType, ruleName string) error {
 	_, err := s.db.Exec(distSQL)
 	if err != nil {
 		return fmt.Errorf("drop rule fail, err: %s", err)
-	}
-	return nil
-}
-
-func (s *server) dropTable(tableName string) error {
-	distSQL := fmt.Sprintf(DistSQLDropTable, tableName)
-	_, err := s.db.Exec(distSQL)
-	if err != nil {
-		return fmt.Errorf("drop table fail, err: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unregister storage unit in shardingsphere If `StorageNode` is `Registered` when it been deleted.

**DISCUSS**: should we reconcile the req if unregister failed?

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?