### PR TITLE
feat: storage node support register and unregsiter for aws aurora cluster

### DIFF
--- a/shardingsphere-operator/api/v1alpha1/storage_node_types.go
+++ b/shardingsphere-operator/api/v1alpha1/storage_node_types.go
@@ -116,8 +116,16 @@ type StorageNode struct {
 type StorageNodeSpec struct {
 	// +kubebuilder:validation:Required
 	StorageProviderName string `json:"storageProviderName"`
-	// +optional
+	// +optional the default database name of the storage node.
+	// if not set, will NOT create database
 	Schema string `json:"schema"`
+	// +optional
+	// only for cluster provider like AWS RDS Cluster/ AWS Aurora Cluster
+	// The Default value is 1 for cluster provider
+	// will not be effective for single instance, instance will always be 1 for single instance
+	// Example: 2, means 2 instances in the cluster(1 primary + 1 reader)
+	// +kubebuilder:default=1
+	Replicas int32 `json:"replicas"`
 }
 
 // StorageNodeStatus defines the actual state of a set of storage units

--- a/shardingsphere-operator/go.mod
+++ b/shardingsphere-operator/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/antlr/antlr4 v0.0.0-20181218183524-be58ebffde8e
 	github.com/chaos-mesh/chaos-mesh/api v0.0.0-20230517110555-afab5b4a7813
 	github.com/cloudnative-pg/cloudnative-pg v1.20.0
-	github.com/database-mesh/golang-sdk v0.0.0-20230605093335-916ac7abc788
+	github.com/database-mesh/golang-sdk v0.0.0-20230606100535-23037381e4fb
 	github.com/go-logr/logr v1.2.4
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/golang/mock v1.6.0

--- a/shardingsphere-operator/go.sum
+++ b/shardingsphere-operator/go.sum
@@ -68,6 +68,8 @@ github.com/database-mesh/golang-sdk v0.0.0-20230605075457-a525bc484e78 h1:442d1d
 github.com/database-mesh/golang-sdk v0.0.0-20230605075457-a525bc484e78/go.mod h1:yUEdo+aGdROl9oC7A1GeDB9/ubUtV2k73uLL+qC3PC4=
 github.com/database-mesh/golang-sdk v0.0.0-20230605093335-916ac7abc788 h1:YEF8BDXHnEiek/EnDVbTCOrVDP7OT3v/R3a8mGM6+vc=
 github.com/database-mesh/golang-sdk v0.0.0-20230605093335-916ac7abc788/go.mod h1:yUEdo+aGdROl9oC7A1GeDB9/ubUtV2k73uLL+qC3PC4=
+github.com/database-mesh/golang-sdk v0.0.0-20230606100535-23037381e4fb h1:p3tpHo24HjA7rW/JMjD9/6klWAVMn4fIefHXKgggVAg=
+github.com/database-mesh/golang-sdk v0.0.0-20230606100535-23037381e4fb/go.mod h1:yUEdo+aGdROl9oC7A1GeDB9/ubUtV2k73uLL+qC3PC4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/shardingsphere-operator/pkg/reconcile/storagenode/aws/aurora_test.go
+++ b/shardingsphere-operator/pkg/reconcile/storagenode/aws/aurora_test.go
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aws
+
+import (
+	"context"
+	"github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/api/v1alpha1"
+
+	"github.com/database-mesh/golang-sdk/aws"
+	"github.com/database-mesh/golang-sdk/aws/client/rds"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ctx = context.Background()
+
+var _ = Describe("Aurora", func() {
+	Context("Test valid create aurora params", func() {
+		It("should be success", func() {
+			sn := &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-valid-create-aurora-params",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						v1alpha1.AnnotationsClusterIdentifier: "test",
+					},
+				},
+			}
+			params := map[string]string{
+				"engine":             "aurora-mysql",
+				"engineVersion":      "5.7",
+				"instanceClass":      "db.t2.small",
+				"clusterIdentifier":  "",
+				"masterUsername":     "root",
+				"masterUserPassword": "root123456",
+			}
+			err := validateCreateAuroraParams(sn, &params)
+			Expect(err).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("Test For AWS Aurora Manually", func() {
+	var (
+		region    string
+		accessKey string
+		secretKey string
+	)
+	Context("Test create aurora cluster with 2 replicas", func() {
+		It("should be success", func() {
+			if region == "" || accessKey == "" || secretKey == "" {
+				Skip("Skip test create aurora cluster")
+			}
+
+			sess := aws.NewSessions().SetCredential(region, accessKey, secretKey).Build()
+			rdsClient := rds.NewService(sess[region])
+			awsClient := NewRdsClient(rdsClient)
+
+			sn := &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-create-aurora-cluster",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						v1alpha1.AnnotationsClusterIdentifier: "test-create-aurora-cluster-identifier",
+					},
+				},
+				Spec: v1alpha1.StorageNodeSpec{
+					Replicas: 2,
+				},
+			}
+			params := map[string]string{
+				"engine":             "aurora-mysql",
+				"engineVersion":      "5.7",
+				"instanceClass":      "db.t2.small",
+				"clusterIdentifier":  "",
+				"masterUsername":     "root",
+				"masterUserPassword": "root123456",
+			}
+
+			Expect(awsClient.CreateAuroraCluster(ctx, sn, params)).Should(Succeed())
+		})
+	})
+	Context("Test Get Aurora Cluster", func() {
+		It("should be success", func() {
+			if region == "" || accessKey == "" || secretKey == "" {
+				Skip("Skip test create aurora cluster")
+			}
+			sess := aws.NewSessions().SetCredential(region, accessKey, secretKey).Build()
+			rdsClient := rds.NewService(sess[region])
+			awsClient := NewRdsClient(rdsClient)
+			sn := &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-get-aurora-cluster",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						v1alpha1.AnnotationsClusterIdentifier: "test-create-aurora-cluster-identifier",
+					},
+				},
+				Spec: v1alpha1.StorageNodeSpec{
+					Replicas: 2,
+				},
+			}
+
+			ac, err := awsClient.GetAuroraCluster(ctx, sn)
+			Expect(err).To(BeNil())
+			Expect(len(ac.DBClusterMembers)).To(Equal(2))
+		})
+	})
+
+	Context("Test Delete Aurora Cluster", func() {
+		It("should be success", func() {
+			if region == "" || accessKey == "" || secretKey == "" {
+				Skip("Skip test create aurora cluster")
+			}
+			sess := aws.NewSessions().SetCredential(region, accessKey, secretKey).Build()
+			rdsClient := rds.NewService(sess[region])
+			awsClient := NewRdsClient(rdsClient)
+
+			sn := &v1alpha1.StorageNode{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-get-aurora-cluster",
+					Namespace: "test-namespace",
+					Annotations: map[string]string{
+						v1alpha1.AnnotationsClusterIdentifier: "test-create-aurora-cluster-identifier",
+					},
+				},
+				Spec: v1alpha1.StorageNodeSpec{
+					StorageProviderName: "test-get-aurora-cluster",
+				},
+			}
+
+			storageProvider := &v1alpha1.StorageProvider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-get-aurora-cluster",
+				},
+				Spec: v1alpha1.StorageProviderSpec{
+					Provisioner:   v1alpha1.ProvisionerAWSAurora,
+					ReclaimPolicy: v1alpha1.StorageReclaimPolicyDelete,
+				},
+			}
+			Expect(awsClient.DeleteAuroraCluster(ctx, sn, storageProvider)).Should(Succeed())
+		})
+	})
+})

--- a/shardingsphere-operator/pkg/reconcile/storagenode/aws/rdsinstance.go
+++ b/shardingsphere-operator/pkg/reconcile/storagenode/aws/rdsinstance.go
@@ -174,15 +174,6 @@ func (c *RdsClient) GetInstancesByFilters(ctx context.Context, filters map[strin
 // DeleteInstance delete rds instance.
 // aws rds instance status doc: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html
 func (c *RdsClient) DeleteInstance(ctx context.Context, node *v1alpha1.StorageNode, storageProvider *v1alpha1.StorageProvider) error {
-	// TODO add more test case.
-	/* TODO set options to skip final snapshot and backup stuff depends on database class ClaimPolicy.
-	"error": "operation error RDS: DeleteDBInstance,
-	https response error StatusCode: 400,
-	RequestID: ae094e3c-d8f1-49ba-aed1-cb0618b3641d,
-	api error InvalidParameterCombination:
-	FinalDBSnapshotIdentifier is required unless SkipFinalSnapshot is specified."
-	*/
-
 	identifier, ok := node.Annotations[v1alpha1.AnnotationsInstanceIdentifier]
 	if !ok {
 		return errors.New("instance identifier is empty")


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `StorageNode.Spec` add `Replicas` to specify the instance number of cluster.
- `StorageNode` support register and unregister for aws aurora cluster's primary endpoint  automatically. The `datasource` name of storage unit is combined with `ds_` and `StorageNode.Name` like `ds_storage_node_1`.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?