### PR TITLE
fix(operator): add start script substition for special version

### DIFF
--- a/charts/apache-shardingsphere-operator-charts/README.md
+++ b/charts/apache-shardingsphere-operator-charts/README.md
@@ -37,7 +37,7 @@ helm install [RELEASE_NAME] shardingsphere/apache-shardingsphere-operator-charts
 | `operator.image.tag`              | image tag                                   | `0.2.0`                                                                 |
 | `operator.imagePullSecrets`       | image pull secret of private repository     | `[]`                                                                    |
 | `operator.resources`              | operator Resources required by the operator | `{}`                                                                    |
-| `operator.health.healthProbePort` | operator health check port                  | `8081`                                                                  |
+| `operator.health.healthProbePort` | operator health check port                  | `8080`                                                                  |
 
 ### ShardingSphere ProxyCluster Parameters
 

--- a/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_chaos.yaml
+++ b/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_chaos.yaml
@@ -1,0 +1,447 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  name: chaos.shardingsphere.apache.org
+spec:
+  group: shardingsphere.apache.org
+  names:
+    kind: Chaos
+    listKind: ChaosList
+    plural: chaos
+    singular: chaos
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Chaos defines a chaos test case for the ShardingSphere Proxy
+          cluster
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ChaosSpec defines the desired state of Chaos
+            properties:
+              injectJob:
+                description: JobSpec specifies the config of job to create
+                properties:
+                  experimental:
+                    type: string
+                  pressure:
+                    type: string
+                  verify:
+                    type: string
+                type: object
+              networkChaos:
+                description: NetworkChaosSpec Fields that need to be configured for
+                  network type chaos
+                properties:
+                  action:
+                    description: NetworkChaosAction specify the action type of network
+                      Chaos
+                    type: string
+                  direction:
+                    description: Direction specifies the direction of action of network
+                      chaos
+                    type: string
+                  duration:
+                    type: string
+                  params:
+                    description: NetworkParams Optional parameters for network type
+                      configuration
+                    properties:
+                      corrupt:
+                        properties:
+                          corrupt:
+                            type: string
+                        type: object
+                      delay:
+                        properties:
+                          jitter:
+                            type: string
+                          latency:
+                            type: string
+                        type: object
+                      duplicate:
+                        properties:
+                          duplicate:
+                            type: string
+                        type: object
+                      loss:
+                        properties:
+                          loss:
+                            type: string
+                        type: object
+                    type: object
+                  source:
+                    description: PodSelector used to select the target of the specified
+                      chaos
+                    properties:
+                      annotationSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      expressionSelectors:
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      labelSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      nodeSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      nodes:
+                        items:
+                          type: string
+                        type: array
+                      pods:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
+                    type: object
+                  target:
+                    description: PodSelector used to select the target of the specified
+                      chaos
+                    properties:
+                      annotationSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      expressionSelectors:
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      labelSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      nodeSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      nodes:
+                        items:
+                          type: string
+                        type: array
+                      pods:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
+                    type: object
+                type: object
+              podChaos:
+                description: PodChaosSpec Fields that need to be configured for pod
+                  type chaos
+                properties:
+                  action:
+                    description: PodChaosAction Specify the action type of pod Chaos
+                    type: string
+                  params:
+                    description: PodActionParams Optional parameters for pod type
+                      configuration
+                    properties:
+                      containerKill:
+                        properties:
+                          containerNames:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      cpuStress:
+                        properties:
+                          cores:
+                            type: integer
+                          duration:
+                            type: string
+                          load:
+                            type: integer
+                        required:
+                        - duration
+                        type: object
+                      memoryStress:
+                        properties:
+                          consumption:
+                            type: string
+                          duration:
+                            type: string
+                          workers:
+                            type: integer
+                        required:
+                        - duration
+                        type: object
+                      podFailure:
+                        properties:
+                          duration:
+                            type: string
+                        type: object
+                      podKill:
+                        properties:
+                          gracePeriod:
+                            format: int64
+                            type: integer
+                        type: object
+                    type: object
+                  selector:
+                    description: PodSelector used to select the target of the specified
+                      chaos
+                    properties:
+                      annotationSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      expressionSelectors:
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      labelSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      namespaces:
+                        items:
+                          type: string
+                        type: array
+                      nodeSelectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      nodes:
+                        items:
+                          type: string
+                        type: array
+                      pods:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
+                    type: object
+                required:
+                - action
+                type: object
+              pressureCfg:
+                properties:
+                  concurrentNum:
+                    type: integer
+                  distSQLs:
+                    items:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        sql:
+                          type: string
+                      required:
+                      - sql
+                      type: object
+                    type: array
+                  duration:
+                    type: string
+                  reqNum:
+                    type: integer
+                  reqTime:
+                    type: string
+                  ssHost:
+                    type: string
+                  zkHost:
+                    type: string
+                required:
+                - concurrentNum
+                - duration
+                - reqNum
+                - reqTime
+                - ssHost
+                type: object
+            type: object
+          status:
+            description: ChaosStatus defines the actual state of Chaos
+            properties:
+              chaosCondition:
+                description: ChaosCondition Show Chaos Progress
+                type: string
+              conditions:
+                description: Result Result `json:"result,omitempty" yaml:"result,omitempty"`
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_chaos.yaml
+++ b/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_chaos.yaml
@@ -1,3 +1,20 @@
+ #
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements.  See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License.  You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_computenodes.yaml
+++ b/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_computenodes.yaml
@@ -1,19 +1,3 @@
- #
- # Licensed to the Apache Software Foundation (ASF) under one or more
- # contributor license agreements.  See the NOTICE file distributed with
- # this work for additional information regarding copyright ownership.
- # The ASF licenses this file to You under the Apache License, Version 2.0
- # (the "License"); you may not use this file except in compliance with
- # the License.  You may obtain a copy of the License at
- #
- #     http://www.apache.org/licenses/LICENSE-2.0
- #
- # Unless required by applicable law or agreed to in writing, software
- # distributed under the License is distributed on an "AS IS" BASIS,
- # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- # See the License for the specific language governing permissions and
- # limitations under the License.
- #
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_computenodes.yaml
+++ b/charts/apache-shardingsphere-operator-charts/crds/shardingsphere.apache.org_computenodes.yaml
@@ -1,3 +1,19 @@
+ #
+ # Licensed to the Apache Software Foundation (ASF) under one or more
+ # contributor license agreements.  See the NOTICE file distributed with
+ # this work for additional information regarding copyright ownership.
+ # The ASF licenses this file to You under the Apache License, Version 2.0
+ # (the "License"); you may not use this file except in compliance with
+ # the License.  You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/apache-shardingsphere-operator-charts/values.yaml
+++ b/charts/apache-shardingsphere-operator-charts/values.yaml
@@ -53,11 +53,11 @@ operator:
   ## @param health.healthProbePort operator health check port
   ##
   health:
-    healthProbePort: 8081
+    healthProbePort: 8080
   ## @param metrics.metricsBindAddress operator metrics port
   ##
   metrics:
-    metricsBindAddress: 8080
+    metricsBindAddress: 9090 
   ## @param featureGates.computeNode operator health check port
   ## @param featureGates.storageNode operator health check port
   ##

--- a/examples/operator/chaos-cpu.yaml
+++ b/examples/operator/chaos-cpu.yaml
@@ -18,16 +18,15 @@
 apiVersion: shardingsphere.apache.org/v1alpha1
 kind: Chaos
 metadata:
-  name: cpu-chaos 
-  namespace: sschaos-test 
+  name: chaos-cpu 
   annotations:
     selector.chaos-mesh.org/mode: one 
 spec:
   podChaos:
     selector:
       labelSelectors:
-        app: foo-sphereex-dbplusengine-proxy
-      namespaces: [ "foo-chaos" ]
+        app: foo
+      namespaces: [ "default" ]
     params:
       cpuStress:
         duration: 1m

--- a/examples/operator/chaos-mem.yaml
+++ b/examples/operator/chaos-mem.yaml
@@ -18,18 +18,16 @@
 apiVersion: shardingsphere.apache.org/v1alpha1
 kind: Chaos
 metadata:
-  name: mem-chaos 
-  namespace: sschaos-test 
+  name: chaos-mem 
   annotations:
     selector.chaos-mesh.org/mode: one 
 spec:
   podChaos:
     selector:
       labelSelectors:
-        app: foo-sphereex-dbplusengine-proxy
-      namespaces: [ "foo-chaos" ]
+        app: foo
+      namespaces: [ "default" ]
     params:
-      podFailure:
       memoryStress:
         duration: 1m
         workers: 2

--- a/examples/operator/chaos-network.yaml
+++ b/examples/operator/chaos-network.yaml
@@ -16,22 +16,27 @@
  #
 
 apiVersion: shardingsphere.apache.org/v1alpha1
-kind: ShardingSphereChaos
+kind: Chaos
 metadata:
-  labels:
-    app.kubernetes.io/name: shardingsphereChaos
-  name: test-chaos 
-  namespace: default
+  name: chaos-network
   annotations:
-    selector.chaos-mesh.org/mode: all
+    target-selector.chaos-mesh.org/mode: "all"
+    selector.chaos-mesh.org/mode: one 
 spec:
-  chaosKind: podChaos
-  podChaos:
-    selector:
+  networkChaos:
+    source:
       labelSelectors:
-        app: foo 
-      namespaces: [ "default" ]
+         app: foo
+      namespaces: 
+      - default 
+    target: 
+      labelSelectors:
+        app.kubernetes.io/name: zookeeper
+      namespaces:
+      - default 
+    action: Loss
+    duration: "2m"
+    direction: "to"
     params:
-      podFailure:
-        duration: 1m
-    action: "podFailure"
+      loss:
+        loss: "80"

--- a/examples/operator/chaos-pod.yaml
+++ b/examples/operator/chaos-pod.yaml
@@ -18,16 +18,15 @@
 apiVersion: shardingsphere.apache.org/v1alpha1
 kind: Chaos
 metadata:
-  name: test-chaos 
-  namespace: sschaos-test 
+  name: chaos-podfailure 
   annotations:
     selector.chaos-mesh.org/mode: one 
 spec:
   podChaos:
     selector:
       labelSelectors:
-        app: foo-sphereex-dbplusengine-proxy
-      namespaces: [ "foo-chaos" ]
+        app: foo
+      namespaces: [ "default" ]
     params:
       podFailure:
         duration: 1m

--- a/examples/operator/shardingsphere-computenode-mysql-cluster-with-agent.yaml
+++ b/examples/operator/shardingsphere-computenode-mysql-cluster-with-agent.yaml
@@ -64,6 +64,10 @@ spec:
         proxy-frontend-database-protocol-type: MySQL
     agentConfig:
       plugins:
+        logging:
+          file:
+            props:
+              level: "INFO"
         metrics:
           prometheus:
             host: "0.0.0.0"

--- a/examples/operator/shardingsphere-computenode-mysql-cluster.yaml
+++ b/examples/operator/shardingsphere-computenode-mysql-cluster.yaml
@@ -25,7 +25,7 @@ spec:
   storageNodeConnector: 
     type: mysql
     version: 5.1.47
-  serverVersion: 5.3.1
+  serverVersion: 5.3.2
   replicas: 1
   selector:
     matchLabels:
@@ -50,7 +50,7 @@ spec:
           type: ZooKeeper
           props:
             timeToLiveSeconds: "600"
-            server-lists: ${PLEASE_REPLACE_THIS_WITH_YOUR_ZOOKEEPER_SERVICE}
+            server-lists: ${PLEASE_REPLACE_THIS_WITH_YOUR_ZOOKEEPER_SERVICE} 
             retryIntervalMilliseconds: "500"
             operationTimeoutMilliseconds: "5000"
             namespace: governance_ds

--- a/examples/operator/shardingsphere-storagenode-aws-aurora-cluster.yaml
+++ b/examples/operator/shardingsphere-storagenode-aws-aurora-cluster.yaml
@@ -20,7 +20,6 @@ apiVersion: shardingsphere.apache.org/v1alpha1
 kind: StorageNode
 metadata:
   name: storage-node-with-aurora-example-1
-  namespace: xwt
   annotations:
     "storageproviders.shardingsphere.apache.org/cluster-identifier": "storage-node-with-aurora-example-1"
     "storageproviders.shardingsphere.apache.org/instance-db-name": "test_db"

--- a/examples/operator/shardingsphere-storagenode-aws-rds-cluster.yaml
+++ b/examples/operator/shardingsphere-storagenode-aws-rds-cluster.yaml
@@ -19,7 +19,6 @@ apiVersion: shardingsphere.apache.org/v1alpha1
 kind: StorageNode
 metadata:
   name: storage-node-with-rds-cluster-1
-  namespace: xwt
   annotations:
     "storageproviders.shardingsphere.apache.org/cluster-identifier": "storage-node-with-rds-cluster-1"
     "storageproviders.shardingsphere.apache.org/instance-db-name": "test_db"
@@ -27,7 +26,7 @@ metadata:
     # annos about register storage unit
     "shardingsphere.apache.org/register-storage-unit-enabled": "false" # set ture if you want to test auto register storage unit.
     "shardingsphere.apache.org/logic-database-name": "sharding_db"
-    "shardingsphere.apache.org/compute-node-name": "shardingsphere-operator-shardingsphere-proxy"
+    "shardingsphere.apache.org/compute-node-name": "foo"
 spec:
   schema: "test_db"
   storageProviderName: aws-rds-cluster-mysql-8.0.32

--- a/shardingsphere-operator/cmd/shardingsphere-operator/manager/option.go
+++ b/shardingsphere-operator/cmd/shardingsphere-operator/manager/option.go
@@ -90,8 +90,8 @@ func ParseOptionsFromCmdFlags() *Options {
 	}
 
 	// Declaring flags for command-line arguments
-	flag.StringVar(&opt.MetricsBindAddress, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&opt.HealthProbeBindAddress, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&opt.MetricsBindAddress, "metrics-bind-address", ":9090", "The address the metric endpoint binds to.")
+	flag.StringVar(&opt.HealthProbeBindAddress, "health-probe-bind-address", ":8080", "The address the probe endpoint binds to.")
 	flag.BoolVar(&opt.LeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/shardingsphere-operator/pkg/kubernetes/deployment/builder.go
+++ b/shardingsphere-operator/pkg/kubernetes/deployment/builder.go
@@ -468,6 +468,8 @@ func NewDeployment(cn *v1alpha1.ComputeNode) *appsv1.Deployment {
 		metricsAnnos[commonAnnotationPrometheusMetricsScheme] = cn.Annotations[commonAnnotationPrometheusMetricsScheme]
 
 		builder.SetShardingSphereProxyPodTemplateAnnotations(metricsAnnos)
+
+		scb.SetCommand([]string{"/opt/shardingsphere-proxy/bin/start.sh"}).SetArgs([]string{"-g"})
 	}
 
 	if cn.Spec.StorageNodeConnector != nil {

--- a/shardingsphere-operator/pkg/kubernetes/deployment/builder.go
+++ b/shardingsphere-operator/pkg/kubernetes/deployment/builder.go
@@ -117,7 +117,7 @@ func NewBootstrapContainerBuilderForMysqlJar() BootstrapContainerBuilder {
 	return &bootstrapContainerBuilder{
 		ContainerBuilder: common.NewContainerBuilder().
 			SetName("download-mysql-jar").
-			SetImage("busybox:1.35.0").
+			SetImage("busybox:1.36").
 			SetCommand([]string{"/bin/sh", "-c", downloadMysqlJarScript}),
 	}
 }
@@ -128,7 +128,7 @@ func NewBootstrapContainerBuilderForAgentBin() BootstrapContainerBuilder {
 	return &bootstrapContainerBuilder{
 		ContainerBuilder: common.NewContainerBuilder().
 			SetName("download-agent-bin-jar").
-			SetImage("busybox:1.35.0").
+			SetImage("busybox:1.36").
 			SetCommand([]string{"/bin/sh", "-c", downloadAgentJarScript}),
 	}
 }

--- a/shardingsphere-operator/pkg/kubernetes/deployment/deployment_test.go
+++ b/shardingsphere-operator/pkg/kubernetes/deployment/deployment_test.go
@@ -145,7 +145,7 @@ func Test_NewDeployment(t *testing.T) {
 							InitContainers: []corev1.Container{
 								{
 									Name:    "download-mysql-jar",
-									Image:   "busybox:1.35.0",
+									Image:   "busybox:1.36",
 									Command: []string{"/bin/sh", "-c", downloadMysqlJarScript},
 									Env: []corev1.EnvVar{
 										{
@@ -300,7 +300,7 @@ func Test_NewDeployment(t *testing.T) {
 							InitContainers: []corev1.Container{
 								{
 									Name:    "download-mysql-jar",
-									Image:   "busybox:1.35.0",
+									Image:   "busybox:1.36",
 									Command: []string{"/bin/sh", "-c", downloadMysqlJarScript},
 									Env: []corev1.EnvVar{
 										{
@@ -317,7 +317,7 @@ func Test_NewDeployment(t *testing.T) {
 								},
 								{
 									Name:    "download-agent-bin-jar",
-									Image:   "busybox:1.35.0",
+									Image:   "busybox:1.36",
 									Command: []string{"/bin/sh", "-c", downloadAgentJarScript},
 									Env: []corev1.EnvVar{
 										{
@@ -348,6 +348,10 @@ func Test_NewDeployment(t *testing.T) {
 										{
 											Name:  defaultMySQLDriverEnvName,
 											Value: "5.1.47",
+										},
+										{
+											Name:  "JAVA_TOOL_OPTIONS",
+											Value: "-javaagent:/opt/shardingsphere-proxy/agent/shardingsphere-agent-5.3.1.jar",
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{

--- a/shardingsphere-operator/pkg/reconcile/common/container.go
+++ b/shardingsphere-operator/pkg/reconcile/common/container.go
@@ -113,11 +113,14 @@ func (c *containerBuilder) SetStartupProbe(probe *v1.Probe) ContainerBuilder {
 // SetEnv set the env of the container
 func (c *containerBuilder) SetEnv(envs []v1.EnvVar) ContainerBuilder {
 	if envs == nil {
+		return c
+	}
+
+	if c.container.Env == nil {
 		c.container.Env = []v1.EnvVar{}
 	}
-	if envs != nil {
-		c.container.Env = envs
-	}
+	c.container.Env = append(c.container.Env, envs...)
+
 	return c
 }
 
@@ -132,7 +135,7 @@ func (c *containerBuilder) SetCommand(cmds []string) ContainerBuilder {
 // SetArgs set the args of the container
 func (c *containerBuilder) SetArgs(args []string) ContainerBuilder {
 	if args != nil {
-		c.container.Command = args
+		c.container.Args = args
 	}
 	return c
 }


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Substitute the start script and append a ${AGENT_PARAM} for 5.3.2
- Set command and argument for enabling agent
- Update default init container image to busybux:1.36 for fix some https issues
- Update operator's default metrics port to 9090
- Polish crd examples

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [x] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?