### PR TITLE
fix: fix storagenode controller may reset params when reconcile aws rds

### DIFF
--- a/charts/apache-shardingsphere-operator-charts/templates/operator_rbac.yaml
+++ b/charts/apache-shardingsphere-operator-charts/templates/operator_rbac.yaml
@@ -90,6 +90,13 @@ rules:
       - update
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - event
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - apps
     resources:
       - deployments
@@ -189,6 +196,32 @@ rules:
   - apiGroups:
       - shardingsphere.apache.org
     resources:
+      - chaos
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - shardingsphere.apache.org
+    resources:
+      - chaos/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - shardingsphere.apache.org
+    resources:
+      - chaos/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - shardingsphere.apache.org
+    resources:
       - computenodes
     verbs:
       - create
@@ -202,32 +235,6 @@ rules:
       - shardingsphere.apache.org
     resources:
       - computenodes/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - shardingsphere.apache.org
-    resources:
-      - shardingspherechaos
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - shardingsphere.apache.org
-    resources:
-      - shardingspherechaos/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - shardingsphere.apache.org
-    resources:
-      - shardingspherechaos/status
     verbs:
       - get
       - patch

--- a/shardingsphere-operator/cmd/shardingsphere-operator/manager/option.go
+++ b/shardingsphere-operator/cmd/shardingsphere-operator/manager/option.go
@@ -32,8 +32,6 @@ import (
 
 	chaosv1alpha1 "github.com/chaos-mesh/chaos-mesh/api/v1alpha1"
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
-	"github.com/database-mesh/golang-sdk/aws"
-	"github.com/database-mesh/golang-sdk/aws/client/rds"
 	dbmeshv1alpha1 "github.com/database-mesh/golang-sdk/kubernetes/api/v1alpha1"
 	"go.uber.org/zap/zapcore"
 	batchV1 "k8s.io/api/batch/v1"
@@ -148,18 +146,15 @@ var featureGatesHandlers = map[string]FeatureGateHandler{
 	},
 	"StorageNode": func(mgr manager.Manager) error {
 		reconciler := &controllers.StorageNodeReconciler{
-			Client:   mgr.GetClient(),
-			Scheme:   mgr.GetScheme(),
-			Log:      mgr.GetLogger(),
-			Recorder: mgr.GetEventRecorderFor(controllers.StorageNodeControllerName),
-			Service:  service.NewServiceClient(mgr.GetClient()),
-			CNPG:     cloudnativepg.NewCloudNativePGClient(mgr.GetClient()),
-		}
-
-		// init aws client if aws credentials are provided
-		if AwsRegion != "" && AwsAccessKeyID != "" && AwsSecretAccessKey != "" {
-			sess := aws.NewSessions().SetCredential(AwsRegion, AwsAccessKeyID, AwsSecretAccessKey).Build()
-			reconciler.AwsRDS = rds.NewService(sess[AwsRegion])
+			Client:             mgr.GetClient(),
+			Scheme:             mgr.GetScheme(),
+			Log:                mgr.GetLogger(),
+			Recorder:           mgr.GetEventRecorderFor(controllers.StorageNodeControllerName),
+			Service:            service.NewServiceClient(mgr.GetClient()),
+			CNPG:               cloudnativepg.NewCloudNativePGClient(mgr.GetClient()),
+			AwsAccessKeyID:     AwsAccessKeyID,
+			AwsSecretAccessKey: AwsSecretAccessKey,
+			AwsRegion:          AwsRegion,
 		}
 
 		if err := reconciler.SetupWithManager(mgr); err != nil {

--- a/shardingsphere-operator/test/e2e/e2e_suite_test.go
+++ b/shardingsphere-operator/test/e2e/e2e_suite_test.go
@@ -30,8 +30,6 @@ import (
 	"github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/pkg/kubernetes/deployment"
 	"github.com/apache/shardingsphere-on-cloud/shardingsphere-operator/pkg/kubernetes/service"
 
-	dbmesh_aws "github.com/database-mesh/golang-sdk/aws"
-	dbmesh_rds "github.com/database-mesh/golang-sdk/aws/client/rds"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -93,14 +91,15 @@ var _ = BeforeSuite(func() {
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{})
 	Expect(err).ToNot(HaveOccurred())
 	// print k8sManager Options
-	sess := dbmesh_aws.NewSessions().SetCredential("AwsRegion", "AwsAccessKeyID", "AwsSecretAccessKey").Build()
 	err = (&controllers.StorageNodeReconciler{
-		Client:   k8sManager.GetClient(),
-		Scheme:   k8sManager.GetScheme(),
-		Log:      ctrl.Log.WithName("controllers").WithName("StorageNode"),
-		Recorder: k8sManager.GetEventRecorderFor("StorageNode"),
-		AwsRDS:   dbmesh_rds.NewService(sess["AwsRegion"]),
-		Service:  service.NewServiceClient(k8sManager.GetClient()),
+		Client:             k8sManager.GetClient(),
+		Scheme:             k8sManager.GetScheme(),
+		Log:                ctrl.Log.WithName("controllers").WithName("StorageNode"),
+		Recorder:           k8sManager.GetEventRecorderFor("StorageNode"),
+		AwsRegion:          "AwsRegion",
+		AwsAccessKeyID:     "AwsAccessKeyID",
+		AwsSecretAccessKey: "AwsSecretAccessKey",
+		Service:            service.NewServiceClient(k8sManager.GetClient()),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/shardingsphere-operator/test/e2e/storage_node_controller_test.go
+++ b/shardingsphere-operator/test/e2e/storage_node_controller_test.go
@@ -31,7 +31,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/DATA-DOG/go-sqlmock"
-	dbmesh_rds "github.com/database-mesh/golang-sdk/aws/client/rds"
+	dbmeshawsrds "github.com/database-mesh/golang-sdk/aws/client/rds"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,10 +77,10 @@ var _ = Describe("StorageNode Controller Suite Test For AWS RDS Instance", func(
 
 		It("should create success", func() {
 			// mock get instance func returns success
-			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstance", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmesh_rds.DescInstance, error) {
-				return &dbmesh_rds.DescInstance{
-					DBInstanceStatus: dbmesh_rds.DBInstanceStatusAvailable,
-					Endpoint: dbmesh_rds.Endpoint{
+			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstance", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmeshawsrds.DescInstance, error) {
+				return &dbmeshawsrds.DescInstance{
+					DBInstanceStatus: dbmeshawsrds.DBInstanceStatusAvailable,
+					Endpoint: dbmeshawsrds.Endpoint{
 						Address: "127.0.0.1",
 						Port:    3306,
 					},
@@ -153,10 +153,10 @@ var _ = Describe("StorageNode Controller Suite Test For AWS RDS Instance", func(
 			Expect(err).Should(Succeed())
 			Expect(dbmock).ShouldNot(BeNil())
 			// mock rds DescribeDBInstances func returns success
-			g := monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstance", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmesh_rds.DescInstance, error) {
-				return &dbmesh_rds.DescInstance{
-					DBInstanceStatus: dbmesh_rds.DBInstanceStatusAvailable,
-					Endpoint: dbmesh_rds.Endpoint{
+			g := monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstance", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmeshawsrds.DescInstance, error) {
+				return &dbmeshawsrds.DescInstance{
+					DBInstanceStatus: dbmeshawsrds.DBInstanceStatusAvailable,
+					Endpoint: dbmeshawsrds.Endpoint{
 						Address: "127.0.0.1",
 						Port:    3306,
 					},
@@ -273,7 +273,7 @@ var _ = Describe("StorageNode Controller Suite Test For AWS RDS Instance", func(
 			}, 20, 2).Should(Equal(v1alpha1.StorageNodePhaseDeleting))
 
 			g.Unpatch()
-			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstance", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmesh_rds.DescInstance, error) {
+			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstance", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmeshawsrds.DescInstance, error) {
 				return nil, nil
 			})
 
@@ -321,21 +321,21 @@ var _ = Describe("StorageNode Controller Suite Test For AWS Aurora Cluster", fun
 		It("Should Success", func() {
 			snName := "test-storage-node-creating"
 			// monkey patch
-			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetAuroraCluster", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmesh_rds.DescCluster, error) {
-				return &dbmesh_rds.DescCluster{
+			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetAuroraCluster", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmeshawsrds.DescCluster, error) {
+				return &dbmeshawsrds.DescCluster{
 					DBClusterIdentifier: clusterIdentifier,
-					Status:              string(dbmesh_rds.DBClusterStatusCreating),
+					Status:              string(dbmeshawsrds.DBClusterStatusCreating),
 					PrimaryEndpoint:     "test-primary-endpoint",
 					ReaderEndpoint:      "test-reader-endpoint",
 					Port:                3306,
 				}, nil
 			})
-			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstancesByFilters", func(_ *aws.RdsClient, _ context.Context, _ map[string][]string) ([]*dbmesh_rds.DescInstance, error) {
-				return []*dbmesh_rds.DescInstance{
+			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstancesByFilters", func(_ *aws.RdsClient, _ context.Context, _ map[string][]string) ([]*dbmeshawsrds.DescInstance, error) {
+				return []*dbmeshawsrds.DescInstance{
 					{
 						DBInstanceIdentifier: fmt.Sprintf("%s-insatnce-0", clusterIdentifier),
-						DBInstanceStatus:     dbmesh_rds.DBInstanceStatusCreating,
-						Endpoint:             dbmesh_rds.Endpoint{Address: "test-instance-0-endpoint", Port: 3306},
+						DBInstanceStatus:     dbmeshawsrds.DBInstanceStatusCreating,
+						Endpoint:             dbmeshawsrds.Endpoint{Address: "test-instance-0-endpoint", Port: 3306},
 					},
 				}, nil
 			})
@@ -359,31 +359,31 @@ var _ = Describe("StorageNode Controller Suite Test For AWS Aurora Cluster", fun
 				newSN := &v1alpha1.StorageNode{}
 				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: snName, Namespace: "default"}, newSN)).Should(Succeed())
 				return newSN.Status.Cluster.Status
-			}, time.Second*10, time.Millisecond*250).Should(Equal(string(dbmesh_rds.DBClusterStatusCreating)))
+			}, time.Second*10, time.Millisecond*250).Should(Equal(string(dbmeshawsrds.DBClusterStatusCreating)))
 		})
 
 		It("should success when cluster is available", func() {
 			snName := "test-storage-node-available"
-			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetAuroraCluster", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmesh_rds.DescCluster, error) {
-				return &dbmesh_rds.DescCluster{
+			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetAuroraCluster", func(_ *aws.RdsClient, _ context.Context, _ *v1alpha1.StorageNode) (*dbmeshawsrds.DescCluster, error) {
+				return &dbmeshawsrds.DescCluster{
 					DBClusterIdentifier: clusterIdentifier,
-					Status:              string(dbmesh_rds.DBClusterStatusAvailable),
+					Status:              string(dbmeshawsrds.DBClusterStatusAvailable),
 					PrimaryEndpoint:     "test-primary-endpoint",
 					ReaderEndpoint:      "test-reader-endpoint",
 					Port:                3306,
 				}, nil
 			})
-			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstancesByFilters", func(_ *aws.RdsClient, _ context.Context, _ map[string][]string) ([]*dbmesh_rds.DescInstance, error) {
-				return []*dbmesh_rds.DescInstance{
+			monkey.PatchInstanceMethod(reflect.TypeOf(&aws.RdsClient{}), "GetInstancesByFilters", func(_ *aws.RdsClient, _ context.Context, _ map[string][]string) ([]*dbmeshawsrds.DescInstance, error) {
+				return []*dbmeshawsrds.DescInstance{
 					{
 						DBInstanceIdentifier: fmt.Sprintf("%s-insatnce-0", clusterIdentifier),
-						DBInstanceStatus:     dbmesh_rds.DBInstanceStatusAvailable,
-						Endpoint:             dbmesh_rds.Endpoint{Address: "test-instance-0-endpoint", Port: 3306},
+						DBInstanceStatus:     dbmeshawsrds.DBInstanceStatusAvailable,
+						Endpoint:             dbmeshawsrds.Endpoint{Address: "test-instance-0-endpoint", Port: 3306},
 					},
 					{
 						DBInstanceIdentifier: fmt.Sprintf("%s-insatnce-1", clusterIdentifier),
-						DBInstanceStatus:     dbmesh_rds.DBInstanceStatusAvailable,
-						Endpoint:             dbmesh_rds.Endpoint{Address: "test-instance-1-endpoint", Port: 3306},
+						DBInstanceStatus:     dbmeshawsrds.DBInstanceStatusAvailable,
+						Endpoint:             dbmeshawsrds.Endpoint{Address: "test-instance-1-endpoint", Port: 3306},
 					},
 				}, nil
 			})


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- Fix operator may set wrong params when reconcile different storage nodes, coz operator set aws rds client once when start up.
- Typo fix

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?