### PR TITLE
feat: add Init before AddInstance while backing up

### DIFF
--- a/pitr/agent/internal/handler/backup.go
+++ b/pitr/agent/internal/handler/backup.go
@@ -45,6 +45,10 @@ func Backup(ctx *fiber.Ctx) error {
 		return fmt.Errorf(efmt, in.Username, len(in.Password), in.DBName, err)
 	}
 
+	if err := pkg.OG.Init(in.DnBackupPath); err != nil {
+		return fmt.Errorf("init instance failed, err: %w", err)
+	}
+
 	// try to add backup instance
 	if err := pkg.OG.AddInstance(in.DnBackupPath, in.Instance); err != nil && !errors.Is(err, cons.InstanceAlreadyExist) {
 		return fmt.Errorf("add instance failed, err wrap: %w", err)


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [ ] Bugfix
- [x] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using `gs_probackup init` to init `dn-backup-path` before AddInstance

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [ ] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?