### PR TITLE
fix: init will not return err if path exists

### DIFF
--- a/pitr/agent/internal/pkg/opengauss.go
+++ b/pitr/agent/internal/pkg/opengauss.go
@@ -162,7 +162,11 @@ func (og *openGauss) Init(backupPath string) error {
 	og.log.Debug(fmt.Sprintf("Init output[msg=%s,err=%v]", output, err))
 
 	if errors.Is(err, cons.CmdOperateFailed) {
-		og.log.Error(fmt.Sprintf("init backup path failure,err: %s, wrap: %s", err, cons.BackupPathAlreadyExist))
+		if strings.Contains(err.Error(), "backup catalog already exist and it's not empty") {
+			og.log.Error(fmt.Sprintf("init backup path failure,err: %s, wrap: %s", err, cons.BackupPathAlreadyExist))
+			return nil
+		}
+
 		return err
 	}
 	if err != nil {


### PR DESCRIPTION
<!-- Please answer these questions before submitting a pull request -->

### Type of change:

<!-- Please delete options that are not relevant. -->

- [x] Bugfix
- [ ] New feature provided
- [ ] Improve performance
- [ ] Backport patches

### What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It should skip the `gs_probackup init` if the backup path is existed.

### Pre-submission checklist:

<!--
Please follow the requirements:
1. Test is required for the feat/fix PR, unless you have a good reason
2. Doc is required for the feat PR
3. Use "request review" to notify the reviewer once you have resolved the review
-->

* [x] Did you explain what problem does this PR solve? Or what new features have been added?
* [ ] Have you added corresponding test cases?
* [ ] Have you modified the corresponding document?